### PR TITLE
Show error details in tags of endpoint's JSON on parse failure

### DIFF
--- a/tornado_swagger/builders.py
+++ b/tornado_swagger/builders.py
@@ -52,7 +52,7 @@ def extract_swagger_docs(endpoint_doc):
         end_point_swagger_doc = yaml.safe_load(endpoint_doc)
         if not isinstance(end_point_swagger_doc, dict):
             raise yaml.YAMLError()
-    except yaml.YAMLError:
+    except yaml.YAMLError as e:
         end_point_swagger_doc = {
             "description": "Swagger document could not be loaded from docstring",
             "tags": ["Invalid Swagger"],

--- a/tornado_swagger/builders.py
+++ b/tornado_swagger/builders.py
@@ -57,6 +57,10 @@ def extract_swagger_docs(endpoint_doc):
             "description": "Swagger document could not be loaded from docstring",
             "tags": ["Invalid Swagger"],
         }
+        error = str(e)
+        if error.strip():
+            end_point_swagger_doc["tags"] += ["Error details:"]
+            end_point_swagger_doc["tags"].extend(error.splitlines())
     return end_point_swagger_doc
 
 


### PR DESCRIPTION
I discovered that it's incredibly difficult to figure out what is wrong with your docstring's YAML when it fails to parse. This pull request adds details about the parse failure to the tags of the relevant endpoint. Since the additional lines are in the tags, they don't cause a further validation failure.