### PR TITLE
Returns the decorated Item

### DIFF
--- a/tornado_swagger/components.py
+++ b/tornado_swagger/components.py
@@ -7,6 +7,8 @@ class RegisterDict(dict):
 
         if doc is not None and "---" in doc:
             self[item.__name__] = extract_swagger_docs(doc)
+        
+        return item
 
 
 class Components(object):


### PR DESCRIPTION
Return the decorated Item so that the schema class can be used

```python
@components.schemas.register
class ArrayOfPostModel(object):
    """
    ---
    type: array
    description: Array of Post model representation
    items:
        $ref: '#/components/schemas/PostModel'
    """
    def __init__(self):
        self.items = []

# So now the user can use the class
response = ArrayOfPostModel()
# response.items = [...]
```